### PR TITLE
Add anonymous_csrf_exempt_always decorator to override ANON_ALWAYS

### DIFF
--- a/session_csrf/__init__.py
+++ b/session_csrf/__init__.py
@@ -76,6 +76,14 @@ class CsrfMiddleware(object):
         if getattr(request, 'csrf_processing_done', False):
             return
 
+        # Allow @anonymous_csrf_exempt_always decorator
+        # to override even ANON_ALWAYS=True
+        if hasattr(request, 'user') and not request.user.is_authenticated():
+            if getattr(view_func, 'anonymous_csrf_exempt_always', False):
+                if hasattr(request, '_anon_csrf_key'):
+                    del request._anon_csrf_key
+                    return
+
         # Allow @csrf_exempt views.
         if getattr(view_func, 'csrf_exempt', False):
             return
@@ -148,6 +156,11 @@ def anonymous_csrf(f):
 def anonymous_csrf_exempt(f):
     """Like @csrf_exempt but only for anonymous requests."""
     f.anonymous_csrf_exempt = True
+    return f
+
+def anonymous_csrf_exempt_always(f):
+    """Like @anonymous_csrf_exempt but even when ANON_ALWAYS is True"""
+    f.anonymous_csrf_exempt_always = True
     return f
 
 


### PR DESCRIPTION
This helps with fixing this bug - https://bugzilla.mozilla.org/show_bug.cgi?id=910691

django-session-csrf provides an ```anonymous_csrf_exempt``` decorator to exempt views from csrf, but when setting ANON_ALWAYS=True in settings.py, the effect of the decorator is overridden and an anonymous CSRF cookie is created on posting feedback via the API.

So I have added an ```anonymous_csrf_exempt_always``` decorator that exempts anonymous CSRF for the decorated views even when ANON_ALWAYS=True.